### PR TITLE
rename calamity rune of kos

### DIFF
--- a/ModDefs/ModCalamity.cs
+++ b/ModDefs/ModCalamity.cs
@@ -29,7 +29,7 @@ public class ModCalamity
         public static int ProfanedShard => ModContent.ItemType<ProfanedShard>(); // Profaned Guardians
         public static int ExoticPheromones => ModContent.ItemType<ExoticPheromones>(); // Dragonfolly
         public static int ProfanedCore => ModContent.ItemType<ProfanedCore>(); // Providence, the Profaned Goddess
-        public static int RuneofKos => ModContent.ItemType<RuneofKos>(); // Storm Weaver, CeaselessVoid and Signus
+        public static int MarkofProvidence => ModContent.ItemType<MarkofProvidence>(); // Storm Weaver, CeaselessVoid and Signus
         public static int Bloodworm => ModContent.ItemType<BloodwormItem>(); // The Old Duke
         public static int CosmicWorm => ModContent.ItemType<CosmicWorm>(); // The Devourer of Gods
         public static int BlessedPhoenixEgg => ModContent.ItemType<YharonEgg>(); // Yharon, Dragon of Rebirth

--- a/Shops/ShopGuide.cs
+++ b/Shops/ShopGuide.cs
@@ -165,7 +165,7 @@ public class ShopGuide : Shop
 
         if (ModCalamity.Bosses.StormWeaverDowned || ModCalamity.Bosses.CeaselessVoidDowned || ModCalamity.Bosses.SignusDowned)
         {
-            AddItem(ModCalamity.Items.RuneofKos, Coins.Gold(3));
+            AddItem(ModCalamity.Items.MarkofProvidence, Coins.Gold(3));
         }
 
         if (ModCalamity.Bosses.OldDukeDowned)

--- a/build.txt
+++ b/build.txt
@@ -1,5 +1,5 @@
 author = valkyrienyanko
-version = 0.22.19
+version = 0.22.20
 displayName = MerchantsPlus
 homepage = https://discord.gg/j8HQZZ76r8
 weakReferences = ThoriumMod, Redemption, CalamityMod


### PR DESCRIPTION
Calamity 2.1 renames runeofkos to markofprovidence, this updates shop to account for it